### PR TITLE
Update "v8-profiler" version and removed "node-usage"

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,13 +1,12 @@
 Package.describe({
   "summary": "Binary Dependencies for Kadira",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "git": "https://github.com/meteorhacks/kadira-binary-deps.git",
   "name": "meteorhacks:kadira-binary-deps"
 });
 
 Npm.depends({
-  "usage": "0.5.0",
-  "v8-profiler": "5.2.0"
+  "v8-profiler": "5.6.5"
 });
 
 Package.onUse(function(api) {
@@ -17,7 +16,7 @@ Package.onUse(function(api) {
 
 Package.onTest(function(api) {
   configure(api);
-  api.versionsFrom('METEOR@0.9.0');
+  api.versionsFrom('METEOR@1.4-beta.9');
   api.use('tinytest');
   api.add_files('test.js', 'server');
 });


### PR DESCRIPTION
This makes it match meteor 1.4's v8 version. "node-usage" is not used now.