### PR TITLE
Update v8 profiler to work with meteor 1.6

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,12 +1,12 @@
 Package.describe({
   "summary": "Binary Dependencies for Kadira",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "git": "https://github.com/meteorhacks/kadira-binary-deps.git",
   "name": "meteorhacks:kadira-binary-deps"
 });
 
 Npm.depends({
-  "v8-profiler": "5.6.5"
+  "v8-profiler": "5.7.0"
 });
 
 Package.onUse(function(api) {
@@ -16,7 +16,7 @@ Package.onUse(function(api) {
 
 Package.onTest(function(api) {
   configure(api);
-  api.versionsFrom('METEOR@1.4-beta.9');
+  api.versionsFrom('1.6');
   api.use('tinytest');
   api.add_files('test.js', 'server');
 });


### PR DESCRIPTION
This PR updates the v8-profiler to the version 5.7.0.

This is needed for meteor 1.6 to not fail at build time.